### PR TITLE
Feat[auth/store]: 로그인 토스트 변수 zustand 저장

### DIFF
--- a/src/app/redirect/components/ClientRedirect.tsx
+++ b/src/app/redirect/components/ClientRedirect.tsx
@@ -2,11 +2,10 @@
 
 import { useEffect } from "react";
 
-import URL from "@/shared/constants/URL";
-import { useSearchParams } from "next/navigation";
-import { useRouter } from "next/navigation";
 import oAuthLogin from "@/features/login/services/oAuthLogin.service";
+import URL from "@/shared/constants/URL";
 import { useAuthStore } from "@/shared/store/authStore";
+import { useRouter, useSearchParams } from "next/navigation";
 
 const ClientRedirect = () => {
   const searchParams = useSearchParams();
@@ -15,7 +14,7 @@ const ClientRedirect = () => {
   const code = searchParams.get("code");
   const state = searchParams.get("state");
 
-  const { setLoggedIn } = useAuthStore();
+  const { setLoggedIn, setLoginSuccess, setWasLoggedIn } = useAuthStore();
 
   const login = async () => {
     if (!code || !state) {
@@ -30,14 +29,15 @@ const ClientRedirect = () => {
 
     const result = await oAuthLogin({ code: code, provider });
     if (result?.status === 200) {
-      localStorage.setItem("login", "true");
-      localStorage.setItem("wasLoggedIn", "true");
+      setLoginSuccess(true);
+      setWasLoggedIn(true);
       setLoggedIn(true);
 
       // 전역 관리된 Path가 있다면 그 URL로 리다이렉트 없다면 HOME으로 리다이렉트
       router.replace(callbackUrl || URL.HOME);
       return;
     }
+    setLoginSuccess(false);
     setLoggedIn(false);
     return router.replace(URL.HOME);
   };

--- a/src/app/studies/components/StudyDescriptionCard.tsx
+++ b/src/app/studies/components/StudyDescriptionCard.tsx
@@ -5,7 +5,7 @@ import Tag from "@/shared/components/atoms/Tag";
 import Typography from "@/shared/components/atoms/Typography";
 import Meta from "@/shared/components/molecules/Meta";
 import { MDXRemote } from "next-mdx-remote-client/rsc";
-import "github-markdown-css/github-markdown.css";
+// import "github-markdown-css/github-markdown.css";
 
 import {
   GetStudyBenefitsResponse,
@@ -16,6 +16,7 @@ import {
 } from "@/shared/types/api/studies";
 
 import ShareButton from "@/app/studies/components/applyStudy/ShareButton";
+import profileImg from "@/asset/images/profile_example.jpeg";
 import Profile from "@/shared/components/atoms/Profile";
 
 interface StudyDescriptionCardProps {
@@ -25,7 +26,6 @@ interface StudyDescriptionCardProps {
   benefitsData: GetStudyBenefitsResponse;
   membersData: GetStudyMembersResponse;
 }
-import profileImg from "@/asset/images/profile_example.jpeg";
 
 const StudyDescriptionCard = ({
   studyDetailData,

--- a/src/features/landing/components/LandingLoginToast.tsx
+++ b/src/features/landing/components/LandingLoginToast.tsx
@@ -2,29 +2,37 @@
 
 import ToastRenderer from "@/shared/components/ToastRenderer";
 import { useToast } from "@/shared/hooks/useToast";
+import { useAuthStore } from "@/shared/store/authStore";
 import { useEffect, useRef } from "react";
 
 const LandingLoginToast = () => {
   const shownRef = useRef(false);
   const toast = useToast();
+  const {
+    hasHydrated,
+    isLoggedIn,
+    loginSuccess,
+    setLoginSuccess,
+    wasLoggedIn,
+    setWasLoggedIn,
+  } = useAuthStore();
 
   useEffect(() => {
+    if (!hasHydrated) return;
     if (shownRef.current) return;
-    const loginStatus = localStorage.getItem("login");
-    const loggedInStatus = localStorage.getItem("wasLoggedIn");
 
-    if (loggedInStatus && !loginStatus) {
+    if (isLoggedIn === false && wasLoggedIn) {
       toast.error("로그인이 만료되었습니다.");
-      localStorage.removeItem("wasLoggedIn");
+      setWasLoggedIn(null);
     }
 
-    if (!loginStatus) return;
-    if (loginStatus === "true") toast.success("로그인에 성공하였습니다.");
-    if (loginStatus === "false") toast.error("로그인에 실패하였습니다.");
+    if (loginSuccess === null) return;
+    if (loginSuccess) toast.success("로그인에 성공하였습니다.");
+    else toast.error("로그인에 실패하였습니다.");
 
     shownRef.current = true;
-    localStorage.removeItem("login");
-  }, []);
+    setLoginSuccess(null);
+  }, [hasHydrated]);
 
   return <ToastRenderer />;
 };

--- a/src/shared/components/system/AppInitializer.tsx
+++ b/src/shared/components/system/AppInitializer.tsx
@@ -7,7 +7,7 @@ interface AppInitializerProps {
   isLoggedIn: boolean;
 }
 const AppInitializer = ({ isLoggedIn }: AppInitializerProps) => {
-  const setLoggedIn = useAuthStore((state) => state.setLoggedIn);
+  const { setLoggedIn } = useAuthStore();
 
   useEffect(() => {
     setLoggedIn(isLoggedIn);

--- a/src/shared/store/authStore.ts
+++ b/src/shared/store/authStore.ts
@@ -2,12 +2,14 @@ import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
 
 interface AuthState {
-  isLoggedIn: boolean;
+  isLoggedIn: boolean; // 지금 로그인 상태인지 저장하는 변수
   setLoggedIn: (v: boolean) => void;
-  loginSuccess: boolean;
-  setLoginSuccess: (v: boolean) => void;
-  wasLoggedIn: boolean;
-  setWasLoggedIn: (v: boolean) => void;
+  loginSuccess: boolean | null; // 로그인 성공/실패 토스트 띄우기 위한 변수
+  setLoginSuccess: (v: boolean | null) => void;
+  wasLoggedIn: boolean | null; // 로그인 만료 토스트 띄우기 위한 변수
+  setWasLoggedIn: (v: boolean | null) => void;
+  hasHydrated: boolean;
+  setHasHydrated: (v: boolean) => void;
 }
 
 // store 값 localStorage랑 연결
@@ -16,14 +18,19 @@ export const useAuthStore = create<AuthState>()(
     (set) => ({
       isLoggedIn: false,
       setLoggedIn: (v) => set({ isLoggedIn: v }),
-      loginSuccess: false,
+      loginSuccess: null,
       setLoginSuccess: (v) => set({ loginSuccess: v }),
-      wasLoggedIn: false,
+      wasLoggedIn: null,
       setWasLoggedIn: (v) => set({ wasLoggedIn: v }),
+      hasHydrated: false,
+      setHasHydrated: (v) => set({ hasHydrated: v }),
     }),
     {
       name: "login", // plz use unique key
       storage: createJSONStorage(() => localStorage), // (optional) by default, 'localStorage' is used
+      onRehydrateStorage: () => (state) => {
+        state?.setHasHydrated?.(true); // hydration 완료 표시
+      },
     }
   )
 );

--- a/src/shared/store/authStore.ts
+++ b/src/shared/store/authStore.ts
@@ -4,6 +4,10 @@ import { createJSONStorage, persist } from "zustand/middleware";
 interface AuthState {
   isLoggedIn: boolean;
   setLoggedIn: (v: boolean) => void;
+  loginSuccess: boolean;
+  setLoginSuccess: (v: boolean) => void;
+  wasLoggedIn: boolean;
+  setWasLoggedIn: (v: boolean) => void;
 }
 
 // store 값 localStorage랑 연결
@@ -12,6 +16,10 @@ export const useAuthStore = create<AuthState>()(
     (set) => ({
       isLoggedIn: false,
       setLoggedIn: (v) => set({ isLoggedIn: v }),
+      loginSuccess: false,
+      setLoginSuccess: (v) => set({ loginSuccess: v }),
+      wasLoggedIn: false,
+      setWasLoggedIn: (v) => set({ wasLoggedIn: v }),
     }),
     {
       name: "login", // plz use unique key


### PR DESCRIPTION
## 유형

- [x] 🚀 Feat: 새 기능 추가
- [x] 🚑️ Fix: 버그 수정
- [x] ♻️ Refactor: 코드 리팩토링
- [ ] 🎨 Style: 코드 스타일 수정 (포맷팅, 세미콜론 등)
- [ ] 💄 Design: UI/스타일 수정 (CSS 등)
- [ ] 📝 Docs: 문서 추가/수정
- [ ] 💡 Comment: 주석 추가/수정
- [ ] 🎉 Init: 프로젝트 초기 설정
- [ ] 🚚 File: 파일/폴더 수정, 이동, 삭제
- [ ] 🐛 Bug: 버그 리포팅 (@FIXME 주석 포함)
- [ ] 🔨 Chore: 기타 (빌드, 패키지 매니저 수정 등)

## 작업 내용

loginSuccess, wasLoggedIn 변수 useAuthStore()에 추가

로그인 만료 상황 시 hydration 전에 useAuthSotre()에서 wasLoggedIn 변수를 꺼내 상태참조

따라서 useAuthStore()에 hydration 변수 추가해 hydration이 끝나면 상태를 참조하도록 함
