### PR TITLE
Feat[ui]: 스터디룸 소개페이지 API 연결 및 레이아웃 카드 API 연결, SIdeBar 현재 route기반으로 active 되게 수정

### DIFF
--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -7,7 +7,8 @@ export default async function Layout({
 }) {
   return (
     <>
-      <AuthInitializerProvider isAuth />
+      {/* 개발시에는 isAuth 무효화 */}
+      <AuthInitializerProvider isAuth={process.env.NODE_ENV === "production"} />
       {children}
     </>
   );

--- a/src/app/(auth)/study-room/[id]/layout.tsx
+++ b/src/app/(auth)/study-room/[id]/layout.tsx
@@ -1,4 +1,3 @@
-"use client";
 import React from "react";
 
 import StudyRoomIntendedCard from "@/app/(auth)/study-room/components/layout/StudyRoomIntendedCard";
@@ -6,13 +5,22 @@ import StudyRoomSideBarCard from "@/app/(auth)/study-room/components/layout/Stud
 import StudyRoomTitleCard from "@/app/(auth)/study-room/components/layout/StudyRoomTitleCard";
 import ImportantNoticeBar from "@/app/(auth)/study-room/components/notice/ImportantNoticeBar";
 import Grid from "@/shared/components/atoms/Grid";
+import { getStudy } from "@/features/studies/services/studies.service";
 
-const layout = ({ children }: { children: React.ReactNode }) => {
+interface StudyRoomLayoutProps {
+  children: React.ReactNode;
+  params: Promise<{ id: string }>;
+}
+
+const layout = async ({ children, params }: StudyRoomLayoutProps) => {
+  const { id } = await params;
+  const studyDetailData = await getStudy(id);
+
   return (
     <>
       <ImportantNoticeBar />
       <Grid cols={12} gap={5}>
-        <StudyRoomTitleCard />
+        <StudyRoomTitleCard data={studyDetailData} />
         <StudyRoomIntendedCard />
         <StudyRoomSideBarCard />
         {children}

--- a/src/app/(auth)/study-room/[id]/overview/page.tsx
+++ b/src/app/(auth)/study-room/[id]/overview/page.tsx
@@ -1,17 +1,26 @@
 import {
   getBenefits,
   getRules,
+  getStudy,
 } from "@/features/studies/services/studies.service";
 import { StudyDetailPageProps } from "@/features/study-room/types/study-room.type";
 import ManageOverviewCard from "../../components/manage-overview/ManageOverviewCard";
+
+import ManageContentCard from "@/app/(auth)/study-room/components/manage-overview/ManageContentCard";
 
 const ManageOverview = async ({ params }: StudyDetailPageProps) => {
   const { id } = await params;
 
   const benefits = (await getBenefits(id)).map((item) => item.content);
   const rules = (await getRules(id)).map((item) => item.content);
+  const studyDetailData = await getStudy(id);
 
-  return <ManageOverviewCard benefits={benefits} rules={rules} studyId={id} />;
+  return (
+    <div className="col-span-12 h-fit tablet:col-span-9 laptop:col-span-10">
+      <ManageContentCard data={studyDetailData} />
+      <ManageOverviewCard benefits={benefits} rules={rules} studyId={id} />
+    </div>
+  );
 };
 
 export default ManageOverview;

--- a/src/app/(auth)/study-room/components/layout/StudyRoomSideBarCard.tsx
+++ b/src/app/(auth)/study-room/components/layout/StudyRoomSideBarCard.tsx
@@ -1,36 +1,41 @@
 "use client";
-import { useParams, useRouter } from "next/navigation";
-import { useState } from "react";
+import { useParams, usePathname, useRouter } from "next/navigation";
 
 import Card from "@/shared/components/atoms/Card";
 import Typography from "@/shared/components/atoms/Typography";
 
-import { ADMIN_MENU_ITEMS, MENU_ITEMS } from "@/shared/constants/SidebarItems";
+import {
+  ADMIN_MENU_ITEMS,
+  MENU_ITEMS,
+  MenuItem,
+} from "@/shared/constants/SidebarItems";
 import StudyRoomTabListWrapper from "./StudyRoomTabListWrapper";
 
 const StudyRoomSideBarCard = () => {
-  const [activeTabState, setActiveTabState] = useState<string>("일정");
   const router = useRouter();
+  const pathname = usePathname();
 
   const params = useParams();
   const id = params.id as string;
 
-  const handleTabClick = (tabName: string, path?: string) => {
-    setActiveTabState(tabName);
-    if (path) router.push(path);
+  const handleTabClick = (path: string) => {
+    router.push(path);
   };
 
   // 메뉴
-  const renderTab = (item: { name: string; icon: string; path?: string }) => (
-    <StudyRoomTabListWrapper
-      key={item.name}
-      active={activeTabState === item.name}
-      onClick={() => handleTabClick(item.name, item.path)}
-    >
-      <i className={`bi ${item.icon}`} />
-      <Typography.P3>{item.name}</Typography.P3>
-    </StudyRoomTabListWrapper>
-  );
+  const renderTab = (item: MenuItem) => {
+    const isActive = pathname === item.path;
+    return (
+      <StudyRoomTabListWrapper
+        key={item.name}
+        active={isActive}
+        onClick={() => handleTabClick(item.path)}
+      >
+        <i className={`bi ${item.icon}`} />
+        <Typography.P3>{item.name}</Typography.P3>
+      </StudyRoomTabListWrapper>
+    );
+  };
 
   return (
     <div className="hidden tablet:col-span-3 tablet:block laptop:col-span-2">

--- a/src/app/(auth)/study-room/components/layout/StudyRoomTitleCard.tsx
+++ b/src/app/(auth)/study-room/components/layout/StudyRoomTitleCard.tsx
@@ -1,34 +1,70 @@
+import { GetStudyDetailResponse } from "@/features/studies/types/studies.api";
 import Card from "@/shared/components/atoms/Card";
 import Tag from "@/shared/components/atoms/Tag";
 import Typography from "@/shared/components/atoms/Typography";
 
-const StudyRoomTitleCard = () => {
+const StudyRoomTitleCard = ({ data }: { data: GetStudyDetailResponse }) => {
+  console.log(data);
+
+  const getProgress = (): number => {
+    const startDate = new Date(data.recruitmentStartDate);
+    const endDate = new Date(data.recruitmentEndDate);
+    const today = new Date();
+
+    const total = endDate.getTime() - startDate.getTime();
+    const current = today.getTime() - startDate.getTime();
+
+    if (today < startDate) return 0;
+    if (today > endDate) return 100;
+
+    return Math.round((current / total) * 100);
+  };
+
   return (
-    <Card className="col-span-12 justify-between gap-2 tablet:col-span-8">
+    <Card className="col-span-12 justify-between tablet:col-span-8">
       <Card.Header className="flex-col gap-3">
-        <Tag.Blue bold border>
-          프로그래밍
-        </Tag.Blue>
+        <div className="flex justify-between gap-2">
+          <div className="flex flex-col gap-2">
+            <Tag.Blue bold border>
+              {data.category}
+            </Tag.Blue>
+          </div>
+          <div className="flex gap-2">
+            <Tag.Green bold border>
+              {data.recruitmentStatus}
+            </Tag.Green>
+            <Tag.Pink bold border>
+              {data.meetingType}
+            </Tag.Pink>
+          </div>
+        </div>
+
         <div className="flex flex-col gap-1">
-          <Typography.Head3>알고리즘 스터디</Typography.Head3>
-          <Typography.P3 className="text-mos-gray-500">
-            매주 화요일 오후 8시에 진행되며, 스터디 전 자료를 미리 읽어와 주시기
-            바랍니다.
-          </Typography.P3>
+          <Typography.Head3>{data.title}</Typography.Head3>
+          <div className="flex gap-2">
+            <Typography.P3 className="text-mos-gray-500">
+              기간: {data.recruitmentStartDate} ~ {data.recruitmentEndDate}{" "}
+              &middot; {data.schedule}
+            </Typography.P3>
+          </div>
         </div>
       </Card.Header>
 
       <Card.Footer className="flex-col gap-1">
         <div className="flex justify-between">
           <Typography.P3 className="text-mos-gray-500">진행률</Typography.P3>
-          <Typography.P3 className="text-mos-gray-500">50%</Typography.P3>
+          <Typography.P3 className="text-mos-gray-500">
+            {getProgress()}%
+          </Typography.P3>
         </div>
-
+        {/* progress bar */}
         <div className="h-3 w-full rounded-full bg-gray-100 dark:bg-gray-700">
           <div
             className="h-3 w-1/2 rounded-full bg-mos-main-500"
-            // style="width: 45%"
-          ></div>
+            style={{
+              width: `${getProgress()}%`,
+            }}
+          />
         </div>
       </Card.Footer>
     </Card>

--- a/src/app/(auth)/study-room/components/manage-overview/ManageContentCard.tsx
+++ b/src/app/(auth)/study-room/components/manage-overview/ManageContentCard.tsx
@@ -1,0 +1,25 @@
+import { GetStudyDetailResponse } from "@/features/studies/types/studies.api";
+import Card from "@/shared/components/atoms/Card";
+import Typography from "@/shared/components/atoms/Typography";
+import CustomMdxRemote from "@/shared/components/system/CustomMdxRemote";
+import React from "react";
+
+interface ContentCardProps {
+  data: GetStudyDetailResponse;
+}
+
+const ManageContentCard = ({ data }: ContentCardProps) => {
+  return (
+    <Card>
+      <Card.Header className="mb-[10px] justify-between border-b pb-2">
+        <Typography.SubTitle1>스터디 소개</Typography.SubTitle1>
+      </Card.Header>
+
+      <Card.Content className="prose prose-sm max-w-full">
+        <CustomMdxRemote content={data.content} />
+      </Card.Content>
+    </Card>
+  );
+};
+
+export default ManageContentCard;

--- a/src/app/(auth)/study-room/components/manage-overview/ManageOverviewCard.tsx
+++ b/src/app/(auth)/study-room/components/manage-overview/ManageOverviewCard.tsx
@@ -87,9 +87,9 @@ const ManageOverviewCard = ({
 
   return (
     <>
-      <Card className="col-span-12 h-fit gap-3 tablet:col-span-9 laptop:col-span-10">
+      <Card className="mt-5">
         <Card.Header className="mb-[10px] justify-between">
-          <Typography.SubTitle1>스터디 규칙/혜택</Typography.SubTitle1>
+          <Typography.SubTitle1>스터디 규칙 &middot; 혜택</Typography.SubTitle1>
         </Card.Header>
 
         <Card.Content>
@@ -131,9 +131,17 @@ const ManageOverviewCard = ({
               />
             )
           ) : tab === 1 ? (
-            <PreviewBox data={ruleData} setState={setIsEditMode} />
+            <PreviewBox
+              data={ruleData}
+              setState={setIsEditMode}
+              label={label}
+            />
           ) : (
-            <PreviewBox data={benefitData} setState={setIsEditMode} />
+            <PreviewBox
+              data={benefitData}
+              setState={setIsEditMode}
+              label={label}
+            />
           )}
         </Card.Content>
       </Card>

--- a/src/app/(auth)/study-room/components/manage-overview/PreviewBox.tsx
+++ b/src/app/(auth)/study-room/components/manage-overview/PreviewBox.tsx
@@ -5,17 +5,14 @@ import { SetStateAction } from "react";
 interface PreviewBoxProps {
   data: string[];
   setState: React.Dispatch<SetStateAction<boolean>>;
+  label: "혜택" | "규칙";
 }
 
-const PreviewBox = ({ data, setState }: PreviewBoxProps) => {
+const PreviewBox = ({ data, label, setState }: PreviewBoxProps) => {
   return (
     <div className="mt-4 px-4">
       <div className="flex flex-col gap-3">
-        {data.map((d, index) => (
-          <div className="rounded-md border p-3 " key={index}>
-            <Typography.P3 className="text-[14px]">{d}</Typography.P3>
-          </div>
-        ))}
+        {<StudyRulesList data={data} label={label} />}
       </div>
 
       {/* 관리자만 볼 수 있는 버튼 */}
@@ -30,6 +27,32 @@ const PreviewBox = ({ data, setState }: PreviewBoxProps) => {
           수정하기
         </Button.Solid>
       </div>
+    </div>
+  );
+};
+
+const StudyRulesList = ({
+  data,
+  label,
+}: {
+  data: PreviewBoxProps["data"];
+  label: PreviewBoxProps["label"];
+}) => {
+  return (
+    <div className="flex flex-col gap-3">
+      {data && data.length > 0 ? ( // data가 존재하는지 먼저 확인
+        data.map((item, index) => (
+          <div className="rounded-md border p-3" key={index}>
+            <Typography.P3 className="text-[14px]">{item}</Typography.P3>
+          </div>
+        ))
+      ) : (
+        <div className="rounded-md border p-3">
+          <Typography.P3 className="text-[14px]">
+            스터디 {label}이 없습니다!
+          </Typography.P3>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/shared/constants/SidebarItems.ts
+++ b/src/shared/constants/SidebarItems.ts
@@ -1,12 +1,17 @@
 import URL from "./URL";
 
-export type MenuItems = {
+export type MenuItem = {
   name: string;
   icon: string;
   path: string;
-}[];
+};
 
-export const MENU_ITEMS = (id: string): MenuItems => [
+export const MENU_ITEMS = (id: string): MenuItem[] => [
+  {
+    name: "소개",
+    icon: "bi-blockquote-left",
+    path: URL.STUDY_ROOM.DETAIL_MANAGE_OVERVIEW(id),
+  },
   {
     name: "일정",
     icon: "bi-calendar",
@@ -33,18 +38,13 @@ export const MENU_ITEMS = (id: string): MenuItems => [
     path: URL.STUDY_ROOM.DETAIL_CHAT(id),
   },
   {
-    name: "규칙/혜택",
-    icon: "bi-book",
-    path: URL.STUDY_ROOM.DETAIL_MANAGE_OVERVIEW(id),
-  },
-  {
     name: "공지사항",
     icon: "bi-megaphone",
     path: URL.STUDY_ROOM.DETAIL_NOTICE(id),
   },
 ];
 
-export const ADMIN_MENU_ITEMS = (id: string): MenuItems => [
+export const ADMIN_MENU_ITEMS = (id: string): MenuItem[] => [
   {
     name: "지원자 관리",
     icon: "bi-person-plus",

--- a/src/shared/styles/global.css
+++ b/src/shared/styles/global.css
@@ -59,3 +59,7 @@ select {
   margin-top: 5px;
   margin-bottom: 5px;
 }
+.prose-sm ul {
+  margin-top: 2px;
+  margin-bottom: 2px;
+}


### PR DESCRIPTION
## 유형
- [x] 🚀 Feat: 새 기능 추가
- [ ] 🚑️ Fix: 버그 수정
- [ ] ♻️ Refactor: 코드 리팩토링
- [x] 🎨 Style: 코드 스타일 수정 (포맷팅, 세미콜론 등)
- [ ] 💄 Design: UI/스타일 수정 (CSS 등)
- [ ] 📝 Docs: 문서 추가/수정
- [ ] 💡 Comment: 주석 추가/수정
- [ ] 🎉 Init: 프로젝트 초기 설정
- [ ] 🚚 File: 파일/폴더 수정, 이동, 삭제
- [ ] 🐛 Bug: 버그 리포팅 (@FIXME 주석 포함)
- [ ] 🔨 Chore: 기타 (빌드, 패키지 매니저 수정 등)

## 작업 내용
- [Feat] StudyRoomTitleCard getStudy API 연결 및 기능 추가
- [Feat] AuthInitializerProvider 개발환경시 isAuth 무효화
- [Feat] StudyRoom Sidebar 라우팅 동기화
- [Feat] 소개 페이지 스터디 소개 카드 추가
- [Feat] PreviewBox 혜택, 규칙 없을 시 예외처리 문구 추가
- [Feat] ManageContentCard 소개 페이지에 추가 및 API 연동 완료
- [Style] prose ul 기본 간격 수정

### 상세 설명 (선택)
- StudyRoomTitleCard에 getStudy API 연결로 스터디 정보 표시 기능 강화.
- AuthInitializerProvider에서 개발환경 isAuth 무효화로 테스트 편의성 향상.
- StudyRoom Sidebar 라우팅 동기화로 네비게이션 일관성 확보.
- 소개 페이지에 스터디 소개 및 ManageContentCard 추가로 정보 접근성 개선.
- PreviewBox 예외처리 문구로 사용자 경험 향상.
- prose ul 간격 수정으로 목록 스타일 가독성 개선.

## 스크린샷 (선택)
![스크린샷 2025-06-11 10 17 54](https://github.com/user-attachments/assets/4e64e33b-f8e7-4bdb-8735-8b548a2ac1b5)
![스크린샷 2025-06-11 10 18 25](https://github.com/user-attachments/assets/3bc7d431-6de3-48d2-a5e4-fde4a1f77924)
![스크린샷 2025-06-11 10 18 35](https://github.com/user-attachments/assets/cbe041c2-d5ce-480c-bad4-ffb07ad241f1)
