### PR TITLE
Feat[StudyRoom]: 스터디룸 일정 카드 및 레이아웃 카드 GET API 연동

### DIFF
--- a/src/app/(auth)/study-room/components/layout/StudyRoomIntendedCard.tsx
+++ b/src/app/(auth)/study-room/components/layout/StudyRoomIntendedCard.tsx
@@ -1,25 +1,52 @@
+"use client";
 import React from "react";
 import StudyRoomSessionCard from "./StudyRoomSessionCard";
 
 import Button from "@/shared/components/atoms/Button";
 import Card from "@/shared/components/atoms/Card";
 import Typography from "@/shared/components/atoms/Typography";
-import { MockStudyScheduleApiResult } from "@/shared/mock/api/studies";
+
+import { useGetStudySchedule } from "@/features/study-room/services/study-room.service";
+import { useParams } from "next/navigation";
 
 const StudyRoomIntendedCard = () => {
+  const params = useParams() as { id: string };
+
+  const { data: scheduleData } = useGetStudySchedule(params.id);
+  const isOngoingStudy = getIsOngoingStudy();
+
+  function getIsOngoingStudy() {
+    if (scheduleData && scheduleData?.length > 0) {
+      const now = Date.now();
+      const start =
+        new Date(scheduleData[0].startDateTime).getTime() - 15 * 60 * 1000;
+      const end = new Date(scheduleData[0].endDateTime).getTime();
+
+      return now >= start && now <= end;
+    } else {
+      return null;
+    }
+  }
+
   return (
     // 진행중인 일정같은 경우는 없다면 예정된 일정 중 가장 빠른걸로 보여준다.
     // 미리 출석(스터디 시작하고 15분 후에는 지각이고, 스터디 시작 전 15분에는 미리출석가능)
     <Card className="col-span-12 gap-2 tablet:col-span-4">
       <Card.Header className="flex justify-between">
         <Typography.SubTitle1>진행중인 스터디 일정</Typography.SubTitle1>
-        <Button.Solid color="Green" active size="sm">
+        <Button.Solid color="Green" active={isOngoingStudy || false} size="sm">
           <i className="bi bi-person-check text-[18px]"></i>
           출석하기
         </Button.Solid>
       </Card.Header>
-      <Card.Content>
-        <StudyRoomSessionCard data={MockStudyScheduleApiResult[0]} />
+      <Card.Content className="h-full items-center justify-center">
+        {isOngoingStudy ? (
+          scheduleData && <StudyRoomSessionCard data={scheduleData[0]} />
+        ) : (
+          <Typography.P3 className="text-mos-gray-500">
+            진행중인 스터디가 없습니다!
+          </Typography.P3>
+        )}
       </Card.Content>
     </Card>
   );

--- a/src/app/(auth)/study-room/components/layout/StudyRoomTitleCard.tsx
+++ b/src/app/(auth)/study-room/components/layout/StudyRoomTitleCard.tsx
@@ -5,26 +5,49 @@ import { useGetStudySchedule } from "@/features/study-room/services/study-room.s
 import Card from "@/shared/components/atoms/Card";
 import Tag from "@/shared/components/atoms/Tag";
 import Typography from "@/shared/components/atoms/Typography";
+import { formatDate } from "@/shared/utils/date";
 import { useParams } from "next/navigation";
 
 const StudyRoomTitleCard = ({ data }: { data: GetStudyDetailResponse }) => {
   const params = useParams() as { id: string };
 
   const { data: scheduleData } = useGetStudySchedule(params.id);
-  console.log(scheduleData);
+  const formatScheduleDate = getFormatStartEndDate();
+
   const getProgress = (): number => {
-    const startDate = new Date(data.recruitmentStartDate);
-    const endDate = new Date(data.recruitmentEndDate);
-    const today = new Date();
+    if (formatScheduleDate) {
+      const startDate = new Date(formatScheduleDate?.startDate);
+      const endDate = new Date(formatScheduleDate?.endDate);
+      const today = new Date();
 
-    const total = endDate.getTime() - startDate.getTime();
-    const current = today.getTime() - startDate.getTime();
+      const total = endDate.getTime() - startDate.getTime();
+      const current = today.getTime() - startDate.getTime();
 
-    if (today < startDate) return 0;
-    if (today > endDate) return 100;
-
-    return Math.round((current / total) * 100);
+      if (today < startDate) return 0;
+      if (today > endDate) return 100;
+      return Math.round((current / total) * 100);
+    } else {
+      return 0;
+    }
   };
+  function getFormatStartEndDate() {
+    if (scheduleData && scheduleData?.length > 0) {
+      const formatStartDate = formatDate(
+        "YYYY-MM-DD",
+        scheduleData[0].startDateTime
+      );
+      const formatEndDate = formatDate(
+        "YYYY-MM-DD",
+        scheduleData[scheduleData.length - 1].endDateTime
+      );
+      return {
+        startDate: formatStartDate,
+        endDate: formatEndDate,
+      };
+    } else {
+      return undefined;
+    }
+  }
 
   return (
     <Card className="col-span-12 justify-between tablet:col-span-8">
@@ -49,8 +72,8 @@ const StudyRoomTitleCard = ({ data }: { data: GetStudyDetailResponse }) => {
           <Typography.Head3>{data.title}</Typography.Head3>
           <div className="flex gap-2">
             <Typography.P3 className="text-mos-gray-500">
-              기간: {data.recruitmentStartDate} ~ {data.recruitmentEndDate}{" "}
-              &middot; {data.schedule}
+              기간: {formatScheduleDate?.startDate} ~{" "}
+              {formatScheduleDate?.endDate} &middot; {data.schedule}
             </Typography.P3>
           </div>
         </div>

--- a/src/app/(auth)/study-room/components/schedule/ScheduleCard.tsx
+++ b/src/app/(auth)/study-room/components/schedule/ScheduleCard.tsx
@@ -7,12 +7,20 @@ import Typography from "@/shared/components/atoms/Typography";
 import StudyRoomSessionCard from "@/app/(auth)/study-room/components/layout/StudyRoomSessionCard";
 import ActionConfirmModal from "@/shared/components/molecules/ActionConfirmModal";
 import useMultiModal from "@/shared/hooks/useMultiModal";
-import { MockStudyScheduleApiResult } from "@/shared/mock/api/studies";
+
 import { StudyScheduleInterface } from "@/shared/types/api/studies/detail";
 import { useState } from "react";
 import ScheduleModal from "./ScheduleModal";
 import { useGetStudySchedule } from "@/features/study-room/services/study-room.service";
 import { useParams } from "next/navigation";
+import { GetStudySchedule } from "@/features/study-room/types/study-room.api";
+
+type ScheduleType = "upcoming" | "past";
+
+interface ScheduleListProps {
+  scheduleData?: GetStudySchedule[];
+  type: ScheduleType;
+}
 
 const ScheduleCard = () => {
   // const { modal, openModal, closeModal } = useModal();
@@ -20,25 +28,24 @@ const ScheduleCard = () => {
   const params = useParams() as { id: string };
 
   const { data: scheduleData } = useGetStudySchedule(params.id);
-  console.log(scheduleData);
 
   const [selectStudyData, setSelectStudyData] =
     useState<StudyScheduleInterface>();
 
-  const handleEdit = (id: number) => {
-    const hasData = MockStudyScheduleApiResult.length > 0;
-    if (hasData) {
-      const findData = MockStudyScheduleApiResult.find(
-        (item) => item.studyId === id
-      );
-      if (findData) {
-        setSelectStudyData(findData);
-        openModal("schedule");
-      } else {
-        throw "Not Found Data";
-      }
-    }
-  };
+  // const handleEdit = (id: number) => {
+  //   const hasData = MockStudyScheduleApiResult.length > 0;
+  //   if (hasData) {
+  //     const findData = MockStudyScheduleApiResult.find(
+  //       (item) => item.studyId === id
+  //     );
+  //     if (findData) {
+  //       setSelectStudyData(findData);
+  //       openModal("schedule");
+  //     } else {
+  //       throw "Not Found Data";
+  //     }
+  //   }
+  // };
 
   return (
     <>
@@ -59,28 +66,10 @@ const ScheduleCard = () => {
           onAdd={() => openModal("schedule")}
           // onDelete={() => openModal("schedule_delete_confirm")}
         >
-          {MockStudyScheduleApiResult.map((item, index) => {
-            return (
-              <StudyRoomSessionCard
-                data={item}
-                key={`${item.studyId}_${index}`}
-                handleEdit={handleEdit}
-                handleDelete={() => {
-                  openModal("schedule_delete_confirm");
-                }}
-              />
-            );
-          })}
+          <ScheduleList scheduleData={scheduleData} type="upcoming" />
         </StudyScheduleCard>
         <StudyScheduleCard title="마감된 스터디 일정">
-          {MockStudyScheduleApiResult.map((item, index) => {
-            return (
-              <StudyRoomSessionCard
-                data={item}
-                key={`${item.studyId}_${index}`}
-              />
-            );
-          })}
+          <ScheduleList scheduleData={scheduleData} type="past" />
         </StudyScheduleCard>
       </div>
       {/* 공지사항 삭제 확인 모달 */}
@@ -130,5 +119,44 @@ const StudyScheduleCard = ({
     </Card>
   );
 };
+
+function ScheduleList({ scheduleData, type }: ScheduleListProps) {
+  if (!scheduleData)
+    return (
+      <div className="flex items-center justify-center p-10 text-xl text-gray-500">
+        데이터를 불러오지 못했습니다!
+      </div>
+    );
+
+  const now = Date.now();
+
+  // 공통 필터링 로직
+  const filteredSchedules = scheduleData.filter((item) =>
+    type === "upcoming"
+      ? new Date(item.endDateTime).getTime() > now
+      : new Date(item.endDateTime).getTime() < now
+  );
+
+  const emptyMessage =
+    type === "upcoming"
+      ? "예정된 스터디 일정이 없습니다!"
+      : "마감된 스터디 일정이 없습니다!";
+
+  if (filteredSchedules.length === 0) {
+    return (
+      <div className="flex items-center justify-center p-10 text-xl text-gray-500">
+        {emptyMessage}
+      </div>
+    );
+  }
+
+  return (
+    <>
+      {filteredSchedules.map((item, index) => (
+        <StudyRoomSessionCard data={item} key={`${item.studyId}_${index}`} />
+      ))}
+    </>
+  );
+}
 
 export default ScheduleCard;

--- a/src/features/study-room/services/study-room.service.ts
+++ b/src/features/study-room/services/study-room.service.ts
@@ -8,6 +8,7 @@ import {
   EditRuleResponse,
   GetAttendancesRequest,
   GetAttendancesResponse,
+  GetStudySchedule,
 } from "../types/study-room.api";
 import { useQuery } from "@tanstack/react-query";
 
@@ -108,7 +109,7 @@ export async function earlyLeave({
 export async function getStudySchedule(studyId: string) {
   const { url, method } = API_ENDPOINT.study.getStudySchedule(studyId);
 
-  return await fetchAPI<GetAttendancesResponse[]>(url, {
+  return await fetchAPI<GetStudySchedule[]>(url, {
     method: method,
     credentials: "include",
   });

--- a/src/features/study-room/types/study-room.api.ts
+++ b/src/features/study-room/types/study-room.api.ts
@@ -36,3 +36,20 @@ export type GetAttendancesRequest = {
 };
 
 export type GetAttendancesResponse = StudyMemberAttendanceInterface;
+
+export interface GetStudySchedule {
+  studyScheduleId: number;
+  title: string;
+  description: string;
+  startDateTime: string;
+  endDateTime: string;
+  studyId: number;
+  studyCurriculumResList: StudyCurriculumResList[];
+}
+
+export interface StudyCurriculumResList {
+  studyCurriculumId: number;
+  sectionId: number;
+  title: string;
+  content: string;
+}


### PR DESCRIPTION
## 유형
- [x] 🚀 Feat: 새 기능 추가
- [x] 🚑️ Fix: 버그 수정
- [ ] ♻️ Refactor: 코드 리팩토링
- [ ] 🎨 Style: 코드 스타일 수정 (포맷팅, 세미콜론 등)
- [ ] 💄 Design: UI/스타일 수정 (CSS 등)
- [ ] 📝 Docs: 문서 추가/수정
- [ ] 💡 Comment: 주석 추가/수정
- [ ] 🎉 Init: 프로젝트 초기 설정
- [ ] 🚚 File: 파일/폴더 수정, 이동, 삭제
- [ ] 🐛 Bug: 버그 리포팅 (@FIXME 주석 포함)
- [ ] 🔨 Chore: 기타 (빌드, 패키지 매니저 수정 등)

## 작업 내용
- [Feat] GetStudySchedule 타입 추가
- [Feat] 진행중인 스터디 일정카드 GET API 연동(schedule)
- [Fix] 타이틀카드 모집기간 => 실제 공부기간으로 변경
- [Feat] 예정, 마감된 스터디 일정 API GET API 연동

### 상세 설명 (선택)
- GetStudySchedule 타입 추가로 스터디 일정 데이터 구조화.
- 진행중인 스터디 일정카드에 GET API 연동으로 실시간 일정 표시.
- 타이틀카드에서 모집기간을 실제 공부기간으로 수정해 정보 정확도 향상.
- 예정 및 마감된 스터디 일정 API 연동으로 전체 일정 관리 기능 확장.

## 스크린샷 (선택)
![스크린샷 2025-06-12 16 58 13](https://github.com/user-attachments/assets/990400c9-23da-4a72-97c8-af893406e6c3)

