### PR TITLE
Feat[study room notice]: 공지사항 모달 상태별 버튼 및 UI 제어 기능 추가

### DIFF
--- a/src/app/(auth)/study-room/components/notice/NoticeCard.tsx
+++ b/src/app/(auth)/study-room/components/notice/NoticeCard.tsx
@@ -34,7 +34,7 @@ const List = (
       {data.map((item) => (
         <div
           key={item.content}
-          className="rounded-md border border-mos-gray-100 px-[15px] py-[10px] hover:border-mos-main hover:bg-gray-50"
+          className="cursor-pointer rounded-md border border-mos-gray-100 px-[15px] py-[10px] hover:border-mos-main hover:bg-gray-50"
           onClick={() => handleEdit(item)}
         >
           <div className="flex items-center gap-2">

--- a/src/app/(auth)/study-room/components/notice/NoticeCard.tsx
+++ b/src/app/(auth)/study-room/components/notice/NoticeCard.tsx
@@ -34,28 +34,23 @@ const List = (
       {data.map((item) => (
         <div
           key={item.content}
-          className="rounded-md border border-mos-gray-100 px-[15px] py-[10px]"
+          className="rounded-md border border-mos-gray-100 px-[15px] py-[10px] hover:border-mos-main hover:bg-gray-50"
+          onClick={() => handleEdit(item)}
         >
-          <div className="mb-2 flex items-center gap-2">
+          <div className="flex items-center gap-2">
             <i className="bi bi-exclamation-circle text-orange-600"></i>
             <div className="flex w-full justify-between">
               <Typography.P3 className="text-[18px]">
                 {item.title}
               </Typography.P3>
-              <div className="flex items-center gap-2">
-                <i
-                  className="bi bi-pencil-square cursor-pointer transition-all duration-200 hover:text-mos-main"
-                  onClick={() => handleEdit(item)}
-                ></i>
-                <Checkbox
-                  className="size-[15px] border border-mos-main"
-                  onClick={() => handleCheckbox(item)}
-                />
-              </div>
+              <Checkbox
+                className="size-[15px] border border-mos-main"
+                onClick={() => handleCheckbox(item)}
+              />
             </div>
           </div>
-          <div className="flex items-center justify-between">
-            <Typography.P3 className="text-[16px] text-mos-gray-700">
+          <div className="mt-2 flex items-center justify-between">
+            <Typography.P3 className="truncate text-[16px] text-mos-gray-700">
               {item.content}
             </Typography.P3>
           </div>
@@ -82,7 +77,6 @@ const NoticeCard = () => {
       alert("삭제할 공지사항을 선택해주세요.");
     } else {
       openModal("notice_delete_confirm");
-      // console.log(selectedNoticeState);
     }
   };
 

--- a/src/app/(auth)/study-room/components/notice/NoticeModal.tsx
+++ b/src/app/(auth)/study-room/components/notice/NoticeModal.tsx
@@ -86,16 +86,16 @@ const NoticeModal = ({ onClose, data, ...props }: NoticeModalProps) => {
     <FormProvider {...methods}>
       <Modal {...props} onClose={onClickCloseBtn}>
         <Modal.Header onClose={onClickCloseBtn}>
-          <div className="flex gap-2">
+          <div className="gap flex items-center gap-2">
             <Typography.Head3>공지사항</Typography.Head3>
             {data && (
               // 데이터가 있는 경우만 수정 버튼 노출
               <Button.Icon
                 color="Main"
-                className="w-5"
+                className="!py-3 px-1"
                 onClick={() => setIsModifyMode((prev) => !prev)}
               >
-                <i className="bi bi-pencil" />
+                <i className="bi bi-pencil text-[14px]" />
               </Button.Icon>
             )}
           </div>

--- a/src/app/(auth)/study-room/components/notice/NoticeModal.tsx
+++ b/src/app/(auth)/study-room/components/notice/NoticeModal.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 
 import Button from "@/shared/components/atoms/Button";
@@ -41,11 +41,17 @@ const NoticeModal = ({ onClose, data, ...props }: NoticeModalProps) => {
   const isActiveBtn = !!noticeData.title && !!noticeData.content;
   // 전역 상태 관리
   const { setImportantNotice } = useNoticeStore();
+  // 수정모드 플래그
+  const [isModifyMode, setIsModifyMode] = useState<boolean>(false);
+  // 필드 활성 여부
+  const disable = data ? !isModifyMode : false;
 
   useEffect(() => {
     if (data) {
       setValue("title", data.title);
       setValue("content", data.content);
+      setValue("isImportantNoticeChecked", data.isImportantNoticeChecked);
+      setValue("isPinned", data.isPinned);
     }
   }, [data, setValue]);
 
@@ -56,19 +62,43 @@ const NoticeModal = ({ onClose, data, ...props }: NoticeModalProps) => {
       localStorage.setItem("importantNoticeContent", data.content);
       setImportantNotice(data.content);
     }
-    reset();
-    onClose();
+
+    onClickCloseBtn();
   };
 
   const onClickCloseBtn = () => {
     onClose();
+    if (data) {
+      reset({
+        title: data.title,
+        content: data.content,
+        isImportantNoticeChecked: data.isImportantNoticeChecked,
+        isPinned: data.isPinned,
+      });
+    } else {
+      reset();
+    }
+
+    setIsModifyMode(false);
   };
 
   return (
     <FormProvider {...methods}>
       <Modal {...props} onClose={onClickCloseBtn}>
         <Modal.Header onClose={onClickCloseBtn}>
-          <Typography.Head3>공지사항 {data ? "수정" : "추가"}</Typography.Head3>
+          <div className="flex gap-2">
+            <Typography.Head3>공지사항</Typography.Head3>
+            {data && (
+              // 데이터가 있는 경우만 수정 버튼 노출
+              <Button.Icon
+                color="Main"
+                className="w-5"
+                onClick={() => setIsModifyMode((prev) => !prev)}
+              >
+                <i className="bi bi-pencil" />
+              </Button.Icon>
+            )}
+          </div>
         </Modal.Header>
 
         <form onSubmit={handleSubmit(onSubmit)}>
@@ -79,6 +109,7 @@ const NoticeModal = ({ onClose, data, ...props }: NoticeModalProps) => {
               placeholder="제목을 입력하세요."
               required
               registerOptions={{ required: "필수 입력입니다." }}
+              disabled={disable}
             />
             <LabelTextAreaInput
               label="내용"
@@ -86,13 +117,17 @@ const NoticeModal = ({ onClose, data, ...props }: NoticeModalProps) => {
               placeholder="내용울 입력하세요."
               required
               registerOptions={{ required: "필수 입력입니다." }}
+              disabled={disable}
             />
             <div className="mb-2 mt-[-10px] flex justify-end gap-2">
-              <Checkbox {...register("isImportantNoticeChecked")} />
+              <Checkbox
+                {...register("isImportantNoticeChecked")}
+                disabled={disable}
+              />
               <Typography.P3 className="text-[14px]">
                 중요 공지로 설정
               </Typography.P3>
-              <Checkbox {...register("isPinned")} />
+              <Checkbox {...register("isPinned")} disabled={disable} />
               <Typography.P3 className="text-[14px]">
                 공지 상단에 고정
               </Typography.P3>
@@ -100,21 +135,36 @@ const NoticeModal = ({ onClose, data, ...props }: NoticeModalProps) => {
           </Modal.Content>
 
           <Modal.Footer>
-            <Button.Ghost
-              color="Gray"
-              onClick={onClickCloseBtn}
-              disabled={false}
-            >
-              취소
-            </Button.Ghost>
-            <Button.Solid
-              type="submit"
-              color="Main"
-              active={isActiveBtn}
-              disabled={!formState.isValid}
-            >
-              확인
-            </Button.Solid>
+            {!isModifyMode && data && (
+              <Button.Solid
+                type="button"
+                color="Main"
+                active
+                onClick={() => onClose()}
+              >
+                확인
+              </Button.Solid>
+            )}
+            {isModifyMode && (
+              <Button.Solid
+                type="submit"
+                color="Main"
+                active={isActiveBtn}
+                disabled={!formState.isValid}
+              >
+                수정
+              </Button.Solid>
+            )}
+            {!isModifyMode && !data && (
+              <Button.Solid
+                type="submit"
+                color="Main"
+                active={isActiveBtn}
+                disabled={!formState.isValid}
+              >
+                등록
+              </Button.Solid>
+            )}
           </Modal.Footer>
         </form>
       </Modal>

--- a/src/app/(auth)/study-room/components/notice/NoticeModal.tsx
+++ b/src/app/(auth)/study-room/components/notice/NoticeModal.tsx
@@ -24,6 +24,7 @@ interface NoticeData {
   title: string;
   content: string;
   isImportantNoticeChecked: boolean;
+  isPinned: boolean;
 }
 
 const NoticeModal = ({ onClose, data, ...props }: NoticeModalProps) => {
@@ -91,11 +92,19 @@ const NoticeModal = ({ onClose, data, ...props }: NoticeModalProps) => {
               <Typography.P3 className="text-[14px]">
                 중요 공지로 설정
               </Typography.P3>
+              <Checkbox {...register("isPinned")} />
+              <Typography.P3 className="text-[14px]">
+                공지 상단에 고정
+              </Typography.P3>
             </div>
           </Modal.Content>
 
           <Modal.Footer>
-            <Button.Ghost color="Gray" onClick={onClickCloseBtn}>
+            <Button.Ghost
+              color="Gray"
+              onClick={onClickCloseBtn}
+              disabled={false}
+            >
               취소
             </Button.Ghost>
             <Button.Solid

--- a/src/features/study-room/types/study-room.type.ts
+++ b/src/features/study-room/types/study-room.type.ts
@@ -16,6 +16,8 @@ export interface StudyNoticeCardInterface {
   title: string;
   content: string;
   writer: string;
+  isImportantNoticeChecked: boolean
+  isPinned: boolean
 }
 
 /* study manage */

--- a/src/shared/components/atoms/Input.tsx
+++ b/src/shared/components/atoms/Input.tsx
@@ -18,6 +18,7 @@ const Input = ({ className, icon, ...props }: InputProps) => {
       <input
         className={cn(
           "focus:ring-mos-main-300 min-w-[200px] rounded-md border border-gray-200 bg-white p-3 text-[14px] text-mos-gray-700 placeholder:text-mos-gray-300 focus:border-mos-main-500 focus:outline-none",
+          "disabled:bg-[#FAFAFA]",
           icon && "pl-10",
           className
         )}

--- a/src/shared/components/atoms/Input.tsx
+++ b/src/shared/components/atoms/Input.tsx
@@ -18,7 +18,7 @@ const Input = ({ className, icon, ...props }: InputProps) => {
       <input
         className={cn(
           "focus:ring-mos-main-300 min-w-[200px] rounded-md border border-gray-200 bg-white p-3 text-[14px] text-mos-gray-700 placeholder:text-mos-gray-300 focus:border-mos-main-500 focus:outline-none",
-          "disabled:bg-[#FAFAFA]",
+          "disabled:border-none disabled:bg-[#FAFAFA]",
           icon && "pl-10",
           className
         )}

--- a/src/shared/components/atoms/Textarea.tsx
+++ b/src/shared/components/atoms/Textarea.tsx
@@ -10,7 +10,7 @@ const Textarea = ({ className, ...props }: TextareaProps) => {
   return (
     <textarea
       className={cn(
-        "h-[90px] w-full rounded-lg border border-gray-200 p-[10px] text-[14px] text-mos-gray-700 placeholder:text-mos-gray-500 focus:border-mos-main-500 focus:outline-none focus:ring-mos-main-500",
+        "focus:ring-mos-main-500, h-[90px] w-full rounded-lg border border-gray-200 p-[10px] text-[14px] text-mos-gray-700 placeholder:text-mos-gray-500 focus:border-mos-main-500 focus:outline-none disabled:border-none",
         className
       )}
       {...props}

--- a/src/shared/mock/api/study-room/index.ts
+++ b/src/shared/mock/api/study-room/index.ts
@@ -1,34 +1,9 @@
 import {
-  StudyCurriculumCardInterface,
   StudyManageCardInterface,
   StudyMemberAttendanceInterface,
   StudyMemberInterface,
   StudyNoticeCardInterface,
 } from "@/features/study-room/types/study-room.type";
-
-import { generateUUID } from "@/shared/utils/generateUUID";
-
-// <CurriculumCard/> 에 쓰일 mock data
-export const MockCurriculumCardApiResult: StudyCurriculumCardInterface[] = [
-  {
-    id: generateUUID(),
-    step: "알고리즘 기초",
-    title: "알고리즘 기초와 복잡도",
-    content: "시간 복잡도, 공간 복잡도, 빅오 표기법에 대해 학습합니다.",
-  },
-  {
-    id: generateUUID(),
-    step: "자료구조",
-    title: "배열과 연결 리스트",
-    content: "기본 자료구조인 배열과 연결 리스트의 특징과 활용법을 학습합니다.",
-  },
-  {
-    id: generateUUID(),
-    step: "자료구조",
-    title: "스택과 큐",
-    content: "스택과 큐의 개념, 구현 방법, 실전 문제 풀이를 진행합니다.",
-  },
-];
 
 // <NoticeCard/> 에 쓰일 mock data
 export const MockNoticeCardApiResult: StudyNoticeCardInterface[] = [
@@ -38,6 +13,8 @@ export const MockNoticeCardApiResult: StudyNoticeCardInterface[] = [
     content:
       "매주 화요일 오후 8시에 진행되며, 스터디 전 자료를 미리 읽어와 주시기 바랍니다!",
     writer: "작성자: 홍길동 • 2024-02-20",
+    isImportantNoticeChecked: true,
+    isPinned:false
   },
   {
     id: 2,
@@ -45,6 +22,8 @@ export const MockNoticeCardApiResult: StudyNoticeCardInterface[] = [
     content:
       "매주 화요일 오후 8시에 진행되며, 스터디 전 자료를 미리 읽어와 주시기 바랍니다.",
     writer: "작성자: 홍길동 • 2024-02-25",
+    isImportantNoticeChecked: false,
+    isPinned:false
   },
 ];
 


### PR DESCRIPTION
## 유형

<!-- 해당되는 유형에 체크해주세요 -->

- [x] 🚀 Feat: 새 기능 추가
- [ ] 🚑️ Fix: 버그 수정
- [ ] ♻️ Refactor: 코드 리팩토링
- [ ] 🎨 Style: 코드 스타일 수정 (포맷팅, 세미콜론 등)
- [x] 💄 Design: UI/스타일 수정 (CSS 등)
- [ ] 📝 Docs: 문서 추가/수정
- [ ] 💡 Comment: 주석 추가/수정
- [ ] 🎉 Init: 프로젝트 초기 설정
- [ ] 🚚 File: 파일/폴더 수정, 이동, 삭제
- [ ] 🐛 Bug: 버그 리포팅 (@FIXME 주석 포함)
- [ ] 🔨 Chore: 기타 (빌드, 패키지 매니저 수정 등)

## 작업 내용
<!-- 필요 시 작업에 대한 상세 설명을 작성해주세요 -->
<!-- 예시) 모달 표시 기능은 사용자 경험 개선을 위해 추가됨 -->

- 공지 리스트 내용 한 줄 초과 시 말줄임(...) 표시 적용
- 공지사항 모달 "공지 상단에 고정" 체크박스 추가
- 공지사항 모달 상태값에 따른 버튼 노출 및 UI 구성 제어
  - 등록 상태: 입력 필드 활성화, 초기값 없음
  - 수정 상태: 입력 필드 활성화, 기존 데이터 제공
  - 조회 상태: 입력 필드 비활성화(읽기 전용), 기존 데이터 제공

## 스크린샷 (선택)

<!-- Responsive Viewer를 사용해 PC, Tablet, Mobile 사이즈를 한 장으로 캡처 -->
<!-- 이미지 첨부 또는 링크 제공 -->


- 등록

<img width="395" alt="image" src="https://github.com/user-attachments/assets/f2d4e073-047a-4a74-b582-e531b0659a13" />


- 수정

<img width="391" alt="image" src="https://github.com/user-attachments/assets/5503b195-bbe8-446e-8197-af877c01c673" />


- 조회

<img width="381" alt="image" src="https://github.com/user-attachments/assets/74a20ea0-b94b-4f99-9c6f-8fc877ed76fa" />


